### PR TITLE
Adding support for delegation token authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ inc/
 Thrift-SASL-Transport-*
 *~
 cpanfile.snapshot
+.idea/

--- a/lib/Thrift/SASL/Transport.pm
+++ b/lib/Thrift/SASL/Transport.pm
@@ -37,7 +37,7 @@ sub new {
     return bless {
         _transport => $transport,
         _sasl      => $sasl,
-        _principal => $principal || sprintf 'hive/%s@REALM.COM',$transport->{transport}{host},
+        ($principal ? (_principal => $principal): ()),
         _debug     => $debug || 0,
     }, $class;
 }
@@ -92,6 +92,9 @@ sub _sasl_handshake {
     # "transport" property, this is a bit confusing imho
     my $client;
     if($self->{_sasl}->mechanism eq 'GSSAPI'){
+        if(!$self->{_principal}){
+            die "Principal needs to be specified for kerberos authentication."
+        }
         my @kerberos_name_split = split('[/@]', $self->{_principal});
         if(scalar @kerberos_name_split != 3){
             die "Kerberos principal name should have 3 parts. Eg: hive/_HOST\@REALM.COM";

--- a/lib/Thrift/SASL/Transport.pm
+++ b/lib/Thrift/SASL/Transport.pm
@@ -33,12 +33,12 @@ use constant {
 };
 
 sub new {
-    my ( $class, $transport, $sasl, $principal, $debug ) = @_;
+    my ( $class, $transport, $sasl, $debug, $principal ) = @_;
     return bless {
         _transport => $transport,
         _sasl      => $sasl,
-        ($principal ? (_principal => $principal): ()),
         _debug     => $debug || 0,
+        ($principal ? (_principal => $principal): ()),
     }, $class;
 }
 


### PR DESCRIPTION
This is to support hiveclient in oozie using delegation tokens. Internally delegation token authentication is done using DIGEST-MD5 sasl mechanism. And the parameters are passed using the username, password extracted from delegation token. Also removed hardcoding of service names, which should be ideally read from kerberos principal in case of GSSAPI auth, and specifically set to null in case of DIGEST auth.